### PR TITLE
fix(arns): move auction out of buy record

### DIFF
--- a/contract/spec/arns_spec.lua
+++ b/contract/spec/arns_spec.lua
@@ -124,7 +124,8 @@ describe("arns", function()
 				local status, result =
 					pcall(arns.buyRecord, "permabuy", "permabuy", nil, "Bob", timestamp, testProcessId)
 				assert.is_false(status)
-				assert.match("Name must be auctioned", result)
+				-- TODO: this will change to `Name must be auctioned` when auctions are impelmented
+				assert.match("Name not available for purchase", result)
 			end
 		)
 

--- a/contract/spec/arns_spec.lua
+++ b/contract/spec/arns_spec.lua
@@ -18,8 +18,7 @@ describe("arns", function()
 
 	describe("buyRecord", function()
 		it("should add a valid lease buyRecord to records objec and transfer balance to the protocol", function()
-			local status, result =
-				pcall(arns.buyRecord, "test-name", "lease", 1, "Bob", false, timestamp, testProcessId)
+			local status, result = pcall(arns.buyRecord, "test-name", "lease", 1, "Bob", timestamp, testProcessId)
 			assert.is_true(status)
 			assert.are.same({
 				purchasePrice = 1500,
@@ -46,7 +45,7 @@ describe("arns", function()
 		end)
 
 		it("defaults to 1 year and lease when not provided", function()
-			local status, result = pcall(arns.buyRecord, "test-name", nil, nil, "Bob", false, timestamp, testProcessId)
+			local status, result = pcall(arns.buyRecord, "test-name", nil, nil, "Bob", timestamp, testProcessId)
 			assert.is_true(status)
 			assert.are.same({
 				purchasePrice = 1500,
@@ -76,7 +75,7 @@ describe("arns", function()
 			"should validate a permabuy request and add the record to global state and deduct balance from caller",
 			function()
 				local status, result =
-					pcall(arns.buyRecord, "test-permabuy", "permabuy", 1, "Bob", false, timestamp, testProcessId)
+					pcall(arns.buyRecord, "test-permabuy", "permabuy", 1, "Bob", timestamp, testProcessId)
 				assert.is_true(status)
 				assert.are.same({
 					purchasePrice = 3000,
@@ -113,8 +112,7 @@ describe("arns", function()
 				undernameCount = 10,
 			}
 			arns.records["test-name"] = existingRecord
-			local status, result =
-				pcall(arns.buyRecord, "test-name", "lease", 1, "Bob", false, timestamp, testProcessId)
+			local status, result = pcall(arns.buyRecord, "test-name", "lease", 1, "Bob", timestamp, testProcessId)
 			assert.is_false(status)
 			assert.match("Name is already registered", result)
 			assert.are.same(existingRecord, arns.records["test-name"])
@@ -126,8 +124,7 @@ describe("arns", function()
 				endTimestamp = 1000,
 			}
 			arns.reserved["test-name"] = reservedName
-			local status, result =
-				pcall(arns.buyRecord, "test-name", "lease", 1, "Bob", false, timestamp, testProcessId)
+			local status, result = pcall(arns.buyRecord, "test-name", "lease", 1, "Bob", timestamp, testProcessId)
 			assert.is_false(status)
 			assert.match("Name is reserved", result)
 			assert.are.same({}, arns.records)
@@ -139,8 +136,7 @@ describe("arns", function()
 				target = "Bob",
 				endTimestamp = 1000,
 			}
-			local status, result =
-				pcall(arns.buyRecord, "test-name", "lease", 1, "Bob", false, timestamp, testProcessId)
+			local status, result = pcall(arns.buyRecord, "test-name", "lease", 1, "Bob", timestamp, testProcessId)
 			local expectation = {
 				endTimestamp = timestamp + constants.oneYearMs,
 				processId = testProcessId,
@@ -156,8 +152,7 @@ describe("arns", function()
 
 		it("should throw an error if the record is in auction", function()
 			arns.auctions["test-name"] = {}
-			local status, result =
-				pcall(arns.buyRecord, "test-name", "lease", 1, "Bob", false, timestamp, testProcessId)
+			local status, result = pcall(arns.buyRecord, "test-name", "lease", 1, "Bob", timestamp, testProcessId)
 			assert.is_false(status)
 			assert.match("Name is in auction", result)
 			assert.are.same({}, arns.records)
@@ -165,8 +160,7 @@ describe("arns", function()
 
 		it("should throw an error if the user does not have enough funds", function()
 			token.balances["Bob"] = 0
-			local status, result =
-				pcall(arns.buyRecord, "test-name", "lease", 1, "Bob", false, timestamp, testProcessId)
+			local status, result = pcall(arns.buyRecord, "test-name", "lease", 1, "Bob", timestamp, testProcessId)
 			assert.is_false(status)
 			assert.match("Insufficient funds", result)
 			assert.are.same({}, arns.records)

--- a/contract/src/arns.lua
+++ b/contract/src/arns.lua
@@ -49,7 +49,8 @@ function arns.buyRecord(name, purchaseType, years, from, timestamp, processId)
 	end
 
 	if not reservedForCaller and (purchaseType == "permabuy" and #name < 12) then
-		error("Name must be auctioned")
+		-- error("Name must be auctioned")
+		-- TODO: for now - just state the name is not available for purchase
 		error("Name not available for purchase")
 	end
 

--- a/contract/src/arns.lua
+++ b/contract/src/arns.lua
@@ -38,6 +38,7 @@ function arns.buyRecord(name, purchaseType, years, from, timestamp, processId)
 		error("Name is already registered")
 	end
 
+	-- todo, handle reserved name timestamps
 	if arns.getReservedName(name) and arns.getReservedName(name).target ~= from then
 		error("Name is reserved")
 	end

--- a/contract/src/gar.lua
+++ b/contract/src/gar.lua
@@ -127,7 +127,7 @@ function gar.increaseOperatorStake(from, qty)
 	end
 
 	if token.getBalance(from) < qty then
-		error("Insufficient funds!")
+		error("Insufficient balance!")
 	end
 
 	token.reduceBalance(from, qty)
@@ -240,7 +240,7 @@ function gar.delegateStake(from, target, qty, currentTimestamp)
 	end
 
 	if token.getBalance(from) < qty then
-		error("Insufficient funds!")
+		error("Insufficient balance!")
 	end
 
 	if gar.gateways[target].status == "leaving" then

--- a/contract/src/gar.lua
+++ b/contract/src/gar.lua
@@ -127,7 +127,7 @@ function gar.increaseOperatorStake(from, qty)
 	end
 
 	if token.getBalance(from) < qty then
-		error("Insufficient balance!")
+		error("Insufficient balance")
 	end
 
 	token.reduceBalance(from, qty)
@@ -240,7 +240,7 @@ function gar.delegateStake(from, target, qty, currentTimestamp)
 	end
 
 	if token.getBalance(from) < qty then
-		error("Insufficient balance!")
+		error("Insufficient balance")
 	end
 
 	if gar.gateways[target].status == "leaving" then

--- a/contract/src/token.lua
+++ b/contract/src/token.lua
@@ -97,7 +97,7 @@ end
 
 function token.increaseVault(from, qty, vaultId, currentTimestamp)
 	if token.getBalance(from) < qty then
-		error("Insufficient balance!")
+		error("Insufficient balance")
 	end
 
 	if token.getVault(from, vaultId) then

--- a/contract/src/token.lua
+++ b/contract/src/token.lua
@@ -97,7 +97,7 @@ end
 
 function token.increaseVault(from, qty, vaultId, currentTimestamp)
 	if token.getBalance(from) < qty then
-		error("Insufficient funds!")
+		error("Insufficient balance!")
 	end
 
 	if token.getVault(from, vaultId) then


### PR DESCRIPTION
We won't handle auctions in the initial implementation and to simplify the logic, we'll move that to submitAuctionBid and not have both implemented in the `buyRecord` interaction.